### PR TITLE
Bump node version to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,5 +25,5 @@ outputs:
     description: Original Pull Request metadata extended with validation data
 
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
It fixes the following error:

```
fetch is not set. Please pass a fetch implementation as new Octokit({ request: { fetch }}).
```